### PR TITLE
Allow CIFS to mount

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -54,7 +54,7 @@
   ansible.builtin.assert:
     that:
       - item.fstype is string
-      - item.fstype in [ "ext3", "ext4", "iso9660", "nfs", "none", "swap", "xfs" ]
+      - item.fstype in [ "cifs", "ext3", "ext4", "iso9660", "nfs", "none", "swap", "xfs" ]
     quiet: yes
   loop: "{{ mount_requests }}"
   loop_control:


### PR DESCRIPTION
Add `cifs` to the list of allowd file system types to be able to mount such volumes.

closes #7